### PR TITLE
Promote QuatVec and scalar to Quaternion

### DIFF
--- a/src/quaternion.jl
+++ b/src/quaternion.jl
@@ -349,5 +349,7 @@ Base.big(q::AbstractQuaternion{T}) where {T<:Real} = wrapper(q){big(T)}(q)
 
 Base.promote_rule(::Type{Q}, ::Type{S}) where {Q<:AbstractQuaternion, S<:Real} =
     wrapper(Q){promote_type(eltype(Q),S)}
+Base.promote_rule(::Type{QuatVec{T}}, ::Type{S}) where {T<:Real, S<:Real} =
+    Quaternion{promote_type(T,S)}
 Base.promote_rule(::Type{Q1}, ::Type{Q2}) where {Q1<:AbstractQuaternion, Q2<:AbstractQuaternion} =
     wrapper(wrapper(Q1), wrapper(Q2)){promote_type(eltype(Q1),eltype(Q2))}

--- a/test/quaternion.jl
+++ b/test/quaternion.jl
@@ -1,4 +1,6 @@
 @testset verbose=true "Quaternion" begin
+    @test eltype([1.0, imx]) === QuaternionF64
+
     @testset "$Q{T}" for Q in [Quaternion, Rotor, QuatVec]
         for T in Types
             @test Q(T) === Q{T}
@@ -19,7 +21,11 @@
                         continue
                     end
                     @test promote_rule(T1, T2) === T1
-                    @test promote_rule(Q{T1}, T2) === Q{T1}
+                    if Q === QuatVec
+                        @test promote_rule(Q{T1}, T2) === Quaternion{T1}
+                    else
+                        @test promote_rule(Q{T1}, T2) === Q{T1}
+                    end
                     @test promote_rule(Q{T1}, Q{T2}) === Q{T1}
                 end
             end


### PR DESCRIPTION
My general rule of thumb is that if any operation involving a pure-vector quaternion would (or could, assuming different values of a given type) result in a general (non-vector) quaternion, then such an operation involving a `QuatVec` should result in a `Quaternion`.  Promotion was violating this rule.  For example, constructing the Vector `[1.0, imx]` would promote these two objects to the same type before constructing the vector.  But since `imx` is a `QuatVec`, this used to mean that `1.0` would be cast to a `QuatVec` — which results in 0.  With this change, they are both promoted to `Quaternion`, thus preserving `1.0`.