### PR TITLE
Replace eltype with basetype

### DIFF
--- a/ext/QuaternionicFastDifferentiationExt.jl
+++ b/ext/QuaternionicFastDifferentiationExt.jl
@@ -53,7 +53,7 @@ let T = FastDifferentiation.Node
     end
 end
 Base.promote_rule(::Type{Q}, ::Type{S}) where {Q<:AbstractQuaternion,S<:FastDifferentiation.Node} =
-    wrapper(Q){promote_type(eltype(Q), S)}
+    wrapper(Q){promote_type(basetype(Q), S)}
 
 
 # # Broadcast-like operations from FastDifferentiation

--- a/ext/QuaternionicFastDifferentiationExt.jl
+++ b/ext/QuaternionicFastDifferentiationExt.jl
@@ -5,7 +5,7 @@ import Quaternionic: normalize, absvec,
     AbstractQuaternion, Quaternion, Rotor, QuatVec,
     quaternion, rotor, quatvec,
     QuatVecF64, RotorF64, QuaternionF64,
-    wrapper, components
+    wrapper, components, basetype
 using PrecompileTools
 isdefined(Base, :get_extension) ? (using FastDifferentiation) : (using ..FastDifferentiation)
 

--- a/ext/QuaternionicSymbolicsExt.jl
+++ b/ext/QuaternionicSymbolicsExt.jl
@@ -5,7 +5,7 @@ import Quaternionic: normalize, absvec,
     AbstractQuaternion, Quaternion, Rotor, QuatVec,
     quaternion, rotor, quatvec,
     QuatVecF64, RotorF64, QuaternionF64,
-    wrapper, components, _pm_ascii
+    wrapper, components, basetype, _pm_ascii
 using PrecompileTools
 isdefined(Base, :get_extension) ? (using Symbolics) : (using ..Symbolics)
 import Symbolics: Latexify

--- a/ext/QuaternionicSymbolicsExt.jl
+++ b/ext/QuaternionicSymbolicsExt.jl
@@ -54,7 +54,7 @@ let T = Symbolics.Num
     end
 end
 Base.promote_rule(::Type{Q}, ::Type{S}) where {Q<:AbstractQuaternion,S<:Symbolics.Num} =
-    wrapper(Q){promote_type(eltype(Q), S)}
+    wrapper(Q){promote_type(basetype(Q), S)}
 
 
 ### Functions that used to appear in base.jl

--- a/src/Quaternionic.jl
+++ b/src/Quaternionic.jl
@@ -10,7 +10,7 @@ export Quaternion, quaternion,
     imx, imy, imz, 𝐢, 𝐣, 𝐤
 export Rotor, rotor, RotorF64, RotorF32, RotorF16
 export QuatVec, quatvec, QuatVecF64, QuatVecF32, QuatVecF16
-export components
+export components, basetype
 export (⋅), (×), (×̂), normalize
 export abs2vec, absvec
 export from_float_array, to_float_array,

--- a/src/algebra.jl
+++ b/src/algebra.jl
@@ -12,9 +12,9 @@ julia> conj(quaternion(1,2,3,4))
 1 - 2𝐢 - 3𝐣 - 4𝐤
 ```
 """
-Base.conj(q::Q) where {Q<:AbstractQuaternion} = wrapper(Q)(q[1], -q[2], -q[3], -q[4])
+Base.conj(q::Q) where {Q<:AbstractQuaternion} = Q(q[1], -q[2], -q[3], -q[4])
 
-Base.:-(q::Q) where {Q<:AbstractQuaternion} = wrapper(Q)(-components(q))
+Base.:-(q::Q) where {Q<:AbstractQuaternion} = Q(-components(q))
 
 
 for TA ∈ (AbstractQuaternion, Rotor, QuatVec)

--- a/src/algebra.jl
+++ b/src/algebra.jl
@@ -13,8 +13,17 @@ julia> conj(quaternion(1,2,3,4))
 ```
 """
 Base.conj(q::Q) where {Q<:AbstractQuaternion} = Q(q[1], -q[2], -q[3], -q[4])
+Base.conj(q::Q) where {Q<:AbstractQuaternion{Bool}} = wrapper(Q)(q[1], -q[2], -q[3], -q[4])
 
 Base.:-(q::Q) where {Q<:AbstractQuaternion} = Q(-components(q))
+Base.:-(q::Q) where {Q<:AbstractQuaternion{Bool}} = wrapper(Q)(-Int.(components(q)))
+
+# Note that, in the two definitions above, the `wrapper` function is used to
+# ensure that the result is of the same type as the input quaternion, but with a different
+# basetype.  This is necessary because `-true` is not a `Bool`, it's the `Int` -1.  This is
+# the only type I can think of where `-` changes the type of the input, so that's the only
+# special case we need.  (I'm assuming `Unsigned` types are not used here.)
+
 
 
 for TA ∈ (AbstractQuaternion, Rotor, QuatVec)

--- a/src/alignment.jl
+++ b/src/alignment.jl
@@ -132,10 +132,10 @@ Now, since we want ``R`` to be a rotor, we simply define it to be the normalized
 sum.
 
 """
-function align(A, B, w)
+function align(A::AbstractArray{<:Rotor}, B::AbstractArray{<:Rotor}, w::AbstractArray{<:Real})
     rotor(sum(w[i] * A[i] * conj(B[i]) for i in eachindex(A, B, w)))
 end
 
-function align(A, B)
+function align(A::AbstractArray{<:Rotor}, B::AbstractArray{<:Rotor})
     rotor(sum(A[i] * conj(B[i]) for i in eachindex(A, B)))
 end

--- a/src/base.jl
+++ b/src/base.jl
@@ -1,13 +1,13 @@
 # Useful functions from Base
 
 function Base.rtoldefault(x::Union{T,Type{T}}, y::Union{S,Type{S}}, atol::Real) where {T<:AbstractQuaternion,S<:AbstractQuaternion}
-    Base.rtoldefault(eltype(x), eltype(y), atol)
+    Base.rtoldefault(basetype(x), basetype(y), atol)
 end
 function Base.rtoldefault(x::Union{T,Type{T}}, y::Union{S,Type{S}}, atol::Real) where {T<:AbstractQuaternion,S<:Number}
-    Base.rtoldefault(eltype(x), y, atol)
+    Base.rtoldefault(basetype(x), y, atol)
 end
 function Base.rtoldefault(x::Union{T,Type{T}}, y::Union{S,Type{S}}, atol::Real) where {T<:Number,S<:AbstractQuaternion}
-    Base.rtoldefault(x, eltype(y), atol)
+    Base.rtoldefault(x, basetype(y), atol)
 end
 
 Base.:(==)(q1::AbstractQuaternion{<:Number}, q2::AbstractQuaternion{<:Number}) = (q1[1]==q2[1]) && (q1[2]==q2[2]) && (q1[3]==q2[3]) && (q1[4]==q2[4])

--- a/src/math.jl
+++ b/src/math.jl
@@ -330,7 +330,7 @@ function Base.:^(q::Rotor, s::Number)
         if q[1] < 0
             # log(q) ≈ π𝐤
             sin_πs, cos_πs = sincospi(oftype(absolutevec, s))
-            return Rotor{eltype(q)}([cos_πs, 0, 0, sin_πs])
+            return Rotor{basetype(q)}([cos_πs, 0, 0, sin_πs])
         end
         # log(q) ≈ 0
         return one(q)

--- a/src/quaternion.jl
+++ b/src/quaternion.jl
@@ -55,7 +55,7 @@ end
 
 quaternion(a::SVector{4,T}) where {T<:Number} = Quaternion{T}(a)
 #quaternion(a::AbstractVector) = Quaternion{T}(SVector{4,T}(a))  # See below
-quaternion(a::AbstractQuaternion) = Quaternion{eltype(a)}(components(a))
+quaternion(a::AbstractQuaternion) = Quaternion{basetype(a)}(components(a))
 quaternion(w,x,y,z) = (v=SVector{4}(w,x,y,z); Quaternion{eltype(v)}(v))
 quaternion(x,y,z) = (v=SVector{4}(false,x,y,z); Quaternion{eltype(v)}(v))
 quaternion(w::T) where {T<:Number} = Quaternion{T}(SVector{4,T}(w, false, false, false))
@@ -387,7 +387,7 @@ end
     end
 end
 Base.@propagate_inbounds Base.getindex(q::AbstractQuaternion, I) = [q[i] for i in I]
-Base.real(::Type{T}) where {T<:AbstractQuaternion} = eltype(T)
+Base.real(::Type{T}) where {T<:AbstractQuaternion} = basetype(T)
 Base.real(q::AbstractQuaternion{T}) where {T<:Number} = q[1]
 Base.imag(q::AbstractQuaternion{T}) where {T<:Number} = @view components(q)[2:4]
 Base.vec(q::AbstractQuaternion{T}) where {T<:Number} = @view components(q)[2:4]
@@ -464,21 +464,22 @@ for T ∈ (AbstractQuaternion, Quaternion, QuatVec, Rotor, Number)
 end
 
 
-Base.eltype(::Type{<:AbstractQuaternion{T}}) where {T} = T
-Base.widen(::Type{Q}) where {Q<:AbstractQuaternion} = wrapper(Q){widen(eltype(Q))}
+basetype(::AbstractQuaternion{T}) where {T} = T
+basetype(::Type{<:AbstractQuaternion{T}}) where {T} = T
+Base.widen(::Type{Q}) where {Q<:AbstractQuaternion} = wrapper(Q){widen(basetype(Q))}
 Base.float(::Type{Q}) where {Q<:AbstractQuaternion{<:AbstractFloat}} = Q
-Base.float(::Type{Q}) where {Q<:AbstractQuaternion} = wrapper(Q){float(eltype(Q))}
+Base.float(::Type{Q}) where {Q<:AbstractQuaternion} = wrapper(Q){float(basetype(Q))}
 Base.float(q::AbstractQuaternion{T}) where {T<:AbstractFloat} = q
 Base.float(q::AbstractQuaternion{T}) where {T} = wrapper(q){float(T)}(float(components(q)))
 
-Base.big(::Type{Q}) where {Q<:AbstractQuaternion} = wrapper(Q){big(eltype(Q))}
+Base.big(::Type{Q}) where {Q<:AbstractQuaternion} = wrapper(Q){big(basetype(Q))}
 Base.big(q::AbstractQuaternion{T}) where {T<:Number} = wrapper(q){big(T)}(q)
 
 Base.promote_rule(::Type{Q}, ::Type{S}) where {Q<:AbstractQuaternion,S<:Number} =
-    wrapper(Q){promote_type(eltype(Q), S)}
+    wrapper(Q){promote_type(basetype(Q), S)}
 Base.promote_rule(::Type{QuatVec{T}}, ::Type{S}) where {T<:Number,S<:Number} =
     Quaternion{promote_type(T, S)}
 Base.promote_rule(::Type{QuatVec{T}}, ::Type{S}) where {T<:Number,S<:AbstractQuaternion} =
-    wrapper(wrapper(QuatVec), wrapper(S)){promote_type(T, eltype(S))}
+    wrapper(wrapper(QuatVec), wrapper(S)){promote_type(T, basetype(S))}
 Base.promote_rule(::Type{Q1}, ::Type{Q2}) where {Q1<:AbstractQuaternion,Q2<:AbstractQuaternion} =
-    wrapper(wrapper(Q1), wrapper(Q2)){promote_type(eltype(Q1), eltype(Q2))}
+    wrapper(wrapper(Q1), wrapper(Q2)){promote_type(basetype(Q1), basetype(Q2))}

--- a/test/algebra.jl
+++ b/test/algebra.jl
@@ -118,4 +118,9 @@ end
             end
         end
     end
+
+    R = Rotor{Float16}(Float16.((-0.3062, 0.09735, -0.1614,  0.933))...)
+    @test conj(conj(R)) == R
+    @test -(-R) == R
+    @test conj(-R) == -conj(R)
 end

--- a/test/algebra.jl
+++ b/test/algebra.jl
@@ -20,8 +20,8 @@ module FundamentalTests
     end
     test_vector_inverse(v::Quaternion) = @test v + (-v) == zero(v)
     function test_vector_scalar_identity(v::Quaternion)
-        @test one(eltype(v)) * v == v
-        @test v * one(eltype(v)) == v
+        @test one(basetype(v)) * v == v
+        @test v * one(basetype(v)) == v
     end
     function test_vector_scalar_multiplication(a, v::Quaternion)
         @test a * v == quaternion(a*v[1], a*v[2], a*v[3], a*v[4])
@@ -59,7 +59,7 @@ module FundamentalTests
     test_involution_norm_imag(x::Quaternion) = @test absvec(x * conj(x)) ≈ 0 atol=eps(abs(x))
 
     # Normed
-    test_norm_maps_to_field(q::Quaternion) = @test typeof(abs2(q)) == eltype(q)
+    test_norm_maps_to_field(q::Quaternion) = @test typeof(abs2(q)) == basetype(q)
     test_norm_nondegenerate(v::Quaternion) = @test iszero(v) ⊻ !iszero(abs2(v))
     test_norm_quadratic(v::Quaternion) = @test abs2(2*v) ≈ 4*abs2(v) rtol=eps(v)
     test_norm_quadratic(a, v::Quaternion) = @test abs2(a*v) ≈ a^2*abs2(v) rtol=eps(v)

--- a/test/alignment.jl
+++ b/test/alignment.jl
@@ -1,15 +1,16 @@
 @testset verbose=true "Alignment" begin
     Random.seed!(1234)
+
     @testset verbose=true "Align QuatVec{$T}" for T in [Float16, Float32, Float64]
         for N in [1, 2, 3, 4, 5, 10, 20]
             a⃗ = randn(QuatVec{T}, N)
             R = randn(Rotor{T})
 
             # Test the exact result
-            b⃗ = R .* a⃗ .* conj(R)
+            b⃗ = R.(a⃗)
             R′ = align(a⃗, b⃗)
             if N > 1
-                @test distance(R, conj(R′)) < 25eps(T)
+                @test distance(R, conj(R′)) < 50eps(T)
             end
             @test maximum(abs, a⃗ - R′ .* b⃗ .* conj(R′)) < 40eps(T)
             @test_throws DimensionMismatch align(a⃗, b⃗[2:end])

--- a/test/base.jl
+++ b/test/base.jl
@@ -233,7 +233,7 @@
 
         # Check "round"
         if T<:AbstractFloat
-            @test eltype(round(T(1.2) + 0imx)) === T
+            @test basetype(round(T(1.2) + 0imx)) === T
             @test round(T(1.2) + 0imx) == 1 + 0imx
             @test round(T(1.2)imx) == 0 + 1imx
             @test round(T(1.2)imy) == 0 + 1imy

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1,0 +1,19 @@
+@testset verbose=true "Issues" begin
+    # This is just to collect the hodgepodge of random tests inspired by issues that have
+    # crept up.  The numbers refer to github issues.
+
+    @testset "Issue #15" begin
+        t = collect(LinRange(-10, 10, 201))
+        @test t .* imz == imz .* t
+        @test t * imz == imz * t
+        @test t * imz == imz .* t
+        @test t .* imz == imz * t
+    end
+
+    @testset "Issue #70" begin
+        p = Rotor(3,-1,2, 1.2)
+        vr = [Rotor(-2,1,1,3), Rotor(2,0,-1,3)]
+        @test typeof(p * vr) === typeof(vr)
+        @test typeof(vr * p) === typeof(vr)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,6 +78,7 @@ end
     addtests("interpolation.jl")
     addtests("gradients.jl")
     addtests("auto_differentiation.jl")
+    addtests("issues.jl")
     addtests("doctests.jl")
 end
 


### PR DESCRIPTION
This will cause breaking changes.  First, `Base.eltype` is no longer defined on any quaternionic type.  It was defined to return the `T` in an `AbstractQuaternion{T}`.  This was the source of some broadcasting issues, because broadcasting essentially recursively searches for the `eltype` of a vector, meaning that a vector of — say — `Quaternion{Float64}` would appear to broadcasting to have type `Float64`.  The new function `basetype` provides the same functionality.  This closes #15 and #70.

While fixing this, a floating-point change in the tests pointed out that `conj` and `-` acting on `Rotor`s would re-normalize, which is not really necessary and — in the case of `Float16` — can significantly change the components even when the original was already normalized.  These now skip the extra normalization step.

Changing that, in turn, uncovered a subtle bug in the method of `align` that was intended to align vectors of `Rotor`s, but did not actually specify the input types, allowing it to mistakenly apply to vectors that were intended to be `QuatVec`s, though one accidentally changed to `Quaternion`.  This change will cause a MethodError to raise when using unintended types.