### PR TITLE
Add Rv and vR functions to compute boost velocities

### DIFF
--- a/src/Lorentz.jl
+++ b/src/Lorentz.jl
@@ -317,3 +317,53 @@ function BR(Λ::Lorentz{T}) where {T<:Real}
     B = Lorentz(abs(ℜΛ) + im * (ℑΛ * conj(R)))
     return B, R
 end
+
+@doc raw"""
+    Rv(Λ::Lorentz{T}) → (R::Rotor{T}, v⃗::QuatVec{T})
+
+Return the pure rotation `R` and (vectorial) boost velocity `v⃗` such that `Λ = R * Boost(η,
+v⃗)` where `η = atanh(β)` is the associated rapidity with `β = norm(v⃗)` as the boost
+parameter.
+
+The boost spinor is `B = cosh(η/2) + im*sinh(η/2)*v̂` in the quaternionic encoding.  Note
+that `v̂` is the unit vector in the direction of `v⃗`.  We can immediately obtain the values
+of those `cosh` and `sinh` factors by taking the scalar part and the norm of the vector
+part.  Using that information, the stable way to compute the velocity vector is to take the
+second term (the complex-imaginary part of `B`), and multiply by `β / sinh(η/2)`.  We can
+use half-angle formulas to show that
+```math
+\frac{β}{\sinh(η/2)}
+= \frac{\tanh(η)}{\sinh(η/2)}
+= \frac{2 \cosh(η/2)}{\cosh^2(η/2) + \sinh^2(η/2)},
+```
+which is made up of those factors we easily obtain from the components of `B`, and does not
+involve any cancellation or division by small numbers.
+
+See also [`vR`](@ref), [`RB`](@ref), and [`BR`](@ref).
+"""
+function Rv(Λ::Lorentz{T}) where {T<:Real}
+    R, B = RB(Λ)
+    sv̂ = QuatVec(ℂimag(B))  # equal to sinh(η/2)*v̂
+    coshη╱2 = real(real(B))  # equal to cosh(η/2); inner real gets scalar part, outer takes ℂreal
+    cosh²η╱2 = (coshη╱2)^2
+    sinh²η╱2 = abs2(sv̂)  # only need *squared* norm of the vector part, sinh(η/2)²
+    v⃗ = sv̂ * (2coshη╱2 / (cosh²η╱2 + sinh²η╱2))
+    return R, v⃗
+end
+
+"""
+    vR(Λ::Lorentz{T}) → (v⃗::QuatVec{T}, R::Rotor{T})
+
+Return the boost velocity `v⃗` and pure rotation `R` such that `Λ = Boost(η, v⃗) * R`.
+
+See also [`Rv`](@ref), [`BR`](@ref), and [`RB`](@ref).
+"""
+function vR(Λ::Lorentz{T}) where {T<:Real}
+    B, R = BR(Λ)
+    sv̂ = QuatVec(ℂimag(B))  # equal to sinh(η/2)*v̂
+    coshη╱2 = real(real(B))  # equal to cosh(η/2); inner real gets scalar part, outer takes ℂreal
+    cosh²η╱2 = (coshη╱2)^2
+    sinh²η╱2 = abs2(sv̂)  # only need *squared* norm of the vector part, sinh(η/2)²
+    v⃗ = sv̂ * (2coshη╱2 / (cosh²η╱2 + sinh²η╱2))
+    return v⃗, R
+end

--- a/src/Quaternionic.jl
+++ b/src/Quaternionic.jl
@@ -15,7 +15,7 @@ export QuatVec, quatvec, QuatVecF64, QuatVecF32, QuatVecF16
 export components, basetype
 public value, iszerovalue
 public ℂconj, ℂreal, ℂimag, ℂreim
-public RB, BR
+public RB, BR, Rv, vR
 export (⋅), (×), (×̂), normalize, norm
 export abs2vec, absvec
 export from_float_array, to_float_array,

--- a/test/lorentz_decomposition.jl
+++ b/test/lorentz_decomposition.jl
@@ -147,7 +147,7 @@ end
     using .LorentzDecompData: same_Λ, is_real_rotor, is_pure_boost
     T = Float32
     ε = 128eps(T)
-    n̂ = QuatVec(T(1/√3), T(1/√3), T(1/√3))
+    n̂ = QuatVec{T}(1, 1, 1)/√T(3)
     B0 = Boost(T(1.2), n̂)
     R0 = Lorentz(rotor(T(0.6), T(0.5), T(0.3), T(0.4)))
     Λ  = R0 * B0
@@ -163,20 +163,35 @@ end
     @test same_Λ(B2 * Lorentz(R2), Λ; atol=ε)
 end
 
-# ── RB and BR are different orderings ─────────────────────────────────────────
+# ── RB and BR equivariance ────────────────────────────────────────────────────
 
-@testitem "RB ≠ BR for generic inputs" tags=[:unit, :fast] setup=[LorentzDecompData] begin
+@testitem "equivariance: B_br = R·B_rb·R⁻¹" tags=[:validation, :fast] setup=[LorentzDecompData] begin
     import Quaternionic: RB, BR
-    using .LorentzDecompData: mixed
-    # For generic non-commuting Lorentz elements, RB and BR yield different B factors
-    n_different = count(mixed) do Λ
-        R_rb, B_rb = RB(Λ)
-        B_br, R_br = BR(Λ)
-        !isapprox(components(B_rb), components(B_br); atol=1e-6) &&
-        !isapprox(components(B_rb), -components(B_br); atol=1e-6)
+    using .LorentzDecompData: mixed, same_Λ
+    using DoubleFloats: Double64
+    # Both decompositions share R = rotor(ℜΛ).  The boost factors are related by
+    # conjugation: B_br = R * B_rb * R⁻¹ (boost direction rotated to lab frame).
+    # Error scales with the boost magnitude cosh(η/2), which bounds it to ~36 eps
+    # for simple inputs and ~139 eps for the accumulated `mixed` products.
+    for T ∈ (Float32, Float64, Double64)
+        ε = 100eps(T)
+        for η ∈ T[0.3, 1.0, 2.5, 5.0]
+            for n̂ ∈ [QuatVec{T}(1,0,0), QuatVec{T}(0,1,0), QuatVec(T(1)/√T(3), T(1)/√T(3), T(1)/√T(3))]
+                for θ ∈ T[π/6, π/3, 2π/3]
+                    Λ = Lorentz(rotor(cos(θ/2), 0, 0, sin(θ/2))) * Boost(η, n̂)
+                    R, B_rb = RB(Λ)
+                    B_br, _ = BR(Λ)
+                    @test same_Λ(B_br, Lorentz(R) * B_rb * Lorentz(conj(R)); atol=ε)
+                end
+            end
+        end
     end
-    # Expect most random mixed elements to give genuinely different B factors
-    @test n_different > length(mixed) ÷ 2
+    # Float64 accumulated products accumulate more error (~139 eps max on this data)
+    for Λ ∈ mixed
+        R, B_rb = RB(Λ)
+        B_br, _ = BR(Λ)
+        @test same_Λ(B_br, Lorentz(R) * B_rb * Lorentz(conj(R)); atol=256eps(Float64))
+    end
 end
 
 # ── Multi-precision convergence ───────────────────────────────────────────────
@@ -189,7 +204,7 @@ end
         θ, η = T(1.3), T(0.8)
         n̂T = [1/√T(3), 1/√T(3), 1/√T(3)]
         B0 = Boost(η, n̂T)
-        R0 = Lorentz(rotor(cos(θ/2), sin(θ/2), zero(T), zero(T)))
+        R0 = Lorentz(rotor(cos(θ/2), sin(θ/2),0, 0))
         Λ  = R0 * B0
         R, B = RB(Λ)
         maximum(abs, components(Lorentz(R) * B) - components(Λ))
@@ -207,4 +222,130 @@ end
     @test err64  ≤ 10eps(Float64)
     @test errD64 ≤ 10eps(Double64)
     @test errBig ≤ 10eps(BigFloat)
+end
+
+# ── Rv and vR ─────────────────────────────────────────────────────────────────
+
+@testitem "Rv/vR: identity" tags=[:unit, :fast, :validation] setup=[LorentzDecompData] begin
+    import Quaternionic: Rv, vR
+    using .LorentzDecompData: same_Λ
+    for T ∈ (Float32, Float64)
+        ε = 10eps(T)
+        Λ = one(Lorentz{T})
+
+        R, v⃗ = Rv(Λ)
+        @test same_Λ(Lorentz(R), Λ; atol=ε)
+        @test norm(v⃗) ≤ ε
+
+        v⃗2, R2 = vR(Λ)
+        @test same_Λ(Lorentz(R2), Λ; atol=ε)
+        @test norm(v⃗2) ≤ ε
+    end
+end
+
+@testitem "Rv/vR: pure rotation → zero velocity" tags=[:unit, :fast, :validation] setup=[LorentzDecompData] begin
+    import Quaternionic: Rv, vR
+    using .LorentzDecompData: rand_rotations, same_Λ
+    ε = 64eps(Float64)
+    for Λ ∈ rand_rotations
+        R, v⃗ = Rv(Λ)
+        @test norm(v⃗) ≤ ε
+        @test same_Λ(Lorentz(R), Λ; atol=ε)
+
+        v⃗2, R2 = vR(Λ)
+        @test norm(v⃗2) ≤ ε
+        @test same_Λ(Lorentz(R2), Λ; atol=ε)
+    end
+end
+
+@testitem "Rv/vR: pure boost → identity rotation and known velocity" tags=[:unit, :fast, :validation] setup=[LorentzDecompData] begin
+    import Quaternionic: Rv, vR
+    using .LorentzDecompData: is_real_rotor
+    for T ∈ (Float32, Float64)
+        ε = 64eps(T)
+        for η ∈ T[0.375, 0.75, 1.5, 2.0]
+            β = tanh(η)
+            for n̂ ∈ [
+                QuatVec{T}(1, 0, 0),
+                QuatVec{T}(0, 1, 0),
+                QuatVec{T}(0, 0, 1),
+                QuatVec{T}(1, 1, 1)/√T(3),
+            ]
+                Λ = Boost(η, n̂)
+
+                R, v⃗ = Rv(Λ)
+                @test is_real_rotor(R; atol=ε)
+                @test norm(v⃗ - β * n̂) ≤ ε
+
+                v⃗2, R2 = vR(Λ)
+                @test is_real_rotor(R2; atol=ε)
+                @test norm(v⃗2 - β * n̂) ≤ ε
+            end
+        end
+    end
+end
+
+@testitem "equivariance: R·v_Rv·R⁻¹ = v_vR" tags=[:validation, :fast] setup=[LorentzDecompData] begin
+    import Quaternionic: Rv, vR
+    using .LorentzDecompData: mixed, rand_rotations, rand_boosts
+    using DoubleFloats: Double64
+    # Both Rv and vR share R = rotor(ℜΛ) (bit-for-bit identical).  The velocities
+    # are related by the adjoint action of R: v_vR = R * v_Rv * R⁻¹.
+    # Holds to ~2 eps: velocities lie in [0,1), so there is no magnitude amplification.
+    for T ∈ (Float32, Float64, Double64)
+        ε = 10eps(T)
+        for η ∈ T[0.3, 1.0, 2.5, 5.0]
+            for n̂ ∈ [QuatVec{T}(1,0,0), QuatVec{T}(0,1,0), QuatVec{T}(1, 1, 1)/√T(3)]
+                for θ ∈ T[π/6, π/3, 2π/3]
+                    Λ = Lorentz(rotor(cos(θ/2), zero(T), zero(T), sin(θ/2))) * Boost(η, n̂)
+                    R, v_rv = Rv(Λ)
+                    v_vr, R2 = vR(Λ)
+                    @test R == R2
+                    @test norm(v_vr - QuatVec(R * v_rv * conj(R))) ≤ ε
+                end
+            end
+        end
+    end
+    # Float64 accumulated products and random inputs: equivariance still holds to ~2 eps
+    for Λ ∈ [mixed; rand_rotations; rand_boosts]
+        R, v_rv = Rv(Λ)
+        v_vr, R2 = vR(Λ)
+        @test R == R2
+        @test norm(v_vr - QuatVec(R * v_rv * conj(R))) ≤ 10eps(Float64)
+    end
+end
+
+@testitem "Rv/vR multi-precision convergence" tags=[:validation, :slow] begin
+    import Quaternionic: Rv, vR
+    using DoubleFloats: Double64
+
+    function rv_error(T)
+        θ, η = T(1.3), T(0.8)
+        n̂ = QuatVec{T}(1, 1, 1)/√T(3)
+        Λ = Lorentz(rotor(cos(θ/2), sin(θ/2), 0, 0)) * Boost(η, n̂)
+        R, v⃗ = Rv(Λ)
+        β = norm(v⃗)
+        B = Boost(atanh(β), v⃗ * inv(β))
+        maximum(abs, components(Lorentz(R) * B) - components(Λ))
+    end
+
+    function vr_error(T)
+        θ, η = T(1.3), T(0.8)
+        n̂ = QuatVec{T}(1, 1, 1)/√T(3)
+        Λ = Lorentz(rotor(cos(θ/2), sin(θ/2), 0, 0)) * Boost(η, n̂)
+        v⃗, R = vR(Λ)
+        β = norm(v⃗)
+        B = Boost(atanh(β), v⃗ * inv(β))
+        maximum(abs, components(B * Lorentz(R)) - components(Λ))
+    end
+
+    @test rv_error(Float32)  ≤ 10eps(Float32)
+    @test rv_error(Float64)  ≤ 10eps(Float64)
+    @test rv_error(Double64) ≤ 10eps(Double64)
+    @test rv_error(BigFloat) ≤ 10eps(BigFloat)
+
+    @test vr_error(Float32)  ≤ 10eps(Float32)
+    @test vr_error(Float64)  ≤ 10eps(Float64)
+    @test vr_error(Double64) ≤ 10eps(Double64)
+    @test vr_error(BigFloat) ≤ 10eps(BigFloat)
 end

--- a/test/lorentz_decomposition.jl
+++ b/test/lorentz_decomposition.jl
@@ -7,22 +7,33 @@
 #   - Multi-precision: error shrinks as precision increases
 
 @testmodule LorentzDecompData begin
-    using Random: seed!
+    using Random: Xoshiro
     using Quaternionic
+    using DoubleFloats: Double64
     import Quaternionic: RB, BR, ℂconj, ℂreal, ℂimag, ℂreim
 
-    seed!(42)
     const n = 20
-    const rand_rotations = [Lorentz(randn(Rotor{Float64})) for _ ∈ 1:n]
 
-    seed!(123)
-    const rand_boosts = [
-        Boost(abs(randn()) + 0.1, QuatVec(normalize(randn(3))))
-        for _ ∈ 1:n
-    ]
+    # Raw data generated at Double64 precision so all float types see the same
+    # rapidity values (different types produce different randn sequences).
+    const _rot_spinors = let rng = Xoshiro(42)
+        [randn(rng, Rotor{Double64}) for _ ∈ 1:n]
+    end
+
+    const _boost_data = let rng = Xoshiro(123)
+        [(min(abs(randn(rng, Double64)), Double64(2)) + Double64(0.1),
+          QuatVec(normalize(randn(rng, Double64, 3))))
+         for _ ∈ 1:n]
+    end
+
+    rand_rotations(T) = [Lorentz(Rotor{T}(T.(components(r))...)) for r ∈ _rot_spinors]
+    rand_boosts(T)    = [Boost(T(η), QuatVec{T}(T.(components(n̂))...)) for (η, n̂) ∈ _boost_data]
 
     # Accumulated products: alternating rotation × boost
-    const mixed = accumulate(*, [x for pair ∈ zip(rand_rotations, rand_boosts) for x ∈ pair])
+    function mixed(T)
+        seq = [x for pair ∈ zip(rand_rotations(T), rand_boosts(T)) for x ∈ pair]
+        accumulate(*, seq)
+    end
 
     # ── Predicate helpers ─────────────────────────────────────────────────────
 
@@ -53,7 +64,8 @@ end
 @testitem "RB/BR: identity" tags=[:unit, :fast, :validation] setup=[LorentzDecompData] begin
     import Quaternionic: RB, BR
     using .LorentzDecompData: same_Λ, is_real_rotor, is_pure_boost
-    for T ∈ (Float32, Float64)
+    using DoubleFloats: Double64
+    for T ∈ (Float32, Float64, Double64)
         ε = 10eps(T)
         Λ = one(Lorentz{T})
 
@@ -72,7 +84,8 @@ end
 @testitem "RB/BR: minus identity" tags=[:unit, :fast, :validation] setup=[LorentzDecompData] begin
     import Quaternionic: RB, BR
     using .LorentzDecompData: same_Λ, is_real_rotor, is_pure_boost
-    for T ∈ (Float32, Float64)
+    using DoubleFloats: Double64
+    for T ∈ (Float32, Float64, Double64)
         ε = 10eps(T)
         Λ = -one(Lorentz{T})
 
@@ -89,30 +102,36 @@ end
 @testitem "RB/BR: pure rotation" tags=[:unit, :fast, :validation] setup=[LorentzDecompData] begin
     import Quaternionic: RB, BR
     using .LorentzDecompData: rand_rotations, same_Λ, is_pure_boost
-    ε = 64eps(Float64)
-    for Λ ∈ rand_rotations
-        R, B = RB(Λ)
-        @test is_pure_boost(B; atol=ε)            # B ≈ identity boost
-        @test same_Λ(Lorentz(R) * B, Λ; atol=ε)
+    using DoubleFloats: Double64
+    for T ∈ (Float32, Float64, Double64)
+        ε = 64eps(T)
+        for Λ ∈ rand_rotations(T)
+            R, B = RB(Λ)
+            @test is_pure_boost(B; atol=ε)            # B ≈ identity boost
+            @test same_Λ(Lorentz(R) * B, Λ; atol=ε)
 
-        B2, R2 = BR(Λ)
-        @test is_pure_boost(B2; atol=ε)
-        @test same_Λ(B2 * Lorentz(R2), Λ; atol=ε)
+            B2, R2 = BR(Λ)
+            @test is_pure_boost(B2; atol=ε)
+            @test same_Λ(B2 * Lorentz(R2), Λ; atol=ε)
+        end
     end
 end
 
 @testitem "RB/BR: pure boost" tags=[:unit, :fast, :validation] setup=[LorentzDecompData] begin
     import Quaternionic: RB, BR
     using .LorentzDecompData: rand_boosts, same_Λ, is_real_rotor
-    ε = 64eps(Float64)
-    for Λ ∈ rand_boosts
-        R, B = RB(Λ)
-        @test is_real_rotor(R; atol=ε)            # R ≈ identity rotation
-        @test same_Λ(Lorentz(R) * B, Λ; atol=ε)
+    using DoubleFloats: Double64
+    for T ∈ (Float32, Float64, Double64)
+        ε = 64eps(T)
+        for Λ ∈ rand_boosts(T)
+            R, B = RB(Λ)
+            @test is_real_rotor(R; atol=ε)            # R ≈ identity rotation
+            @test same_Λ(Lorentz(R) * B, Λ; atol=ε)
 
-        B2, R2 = BR(Λ)
-        @test is_real_rotor(R2; atol=ε)
-        @test same_Λ(B2 * Lorentz(R2), Λ; atol=ε)
+            B2, R2 = BR(Λ)
+            @test is_real_rotor(R2; atol=ε)
+            @test same_Λ(B2 * Lorentz(R2), Λ; atol=ε)
+        end
     end
 end
 
@@ -121,24 +140,31 @@ end
 @testitem "RB round-trip: random mixed" tags=[:validation, :fast] setup=[LorentzDecompData] begin
     import Quaternionic: RB
     using .LorentzDecompData: mixed, same_Λ, is_real_rotor, is_pure_boost
-    ε = 4096eps(Float64)  # products of ~40 elements accumulate ~40× eps error
-    for Λ ∈ mixed
-        R, B = RB(Λ)
-        @test is_real_rotor(R; atol=ε)
-        @test is_pure_boost(B; atol=ε)
-        @test same_Λ(Lorentz(R) * B, Λ; atol=ε)
+    using DoubleFloats: Double64
+    # Errors scale as N×eps(T)×cosh(η/2): N≤109 for structural checks, N≤23 for round-trip.
+    for T ∈ (Float32, Float64, Double64)
+        for Λ ∈ mixed(T)
+            R, B = RB(Λ)
+            cosh_half = abs(real(getfield(B, :components)[1]))
+            @test is_real_rotor(R; atol=128eps(T)*cosh_half)
+            @test is_pure_boost(B; atol=128eps(T)*cosh_half)
+            @test same_Λ(Lorentz(R) * B, Λ; atol=32eps(T)*cosh_half)
+        end
     end
 end
 
 @testitem "BR round-trip: random mixed" tags=[:validation, :fast] setup=[LorentzDecompData] begin
     import Quaternionic: BR
     using .LorentzDecompData: mixed, same_Λ, is_real_rotor, is_pure_boost
-    ε = 200eps(Float64)
-    for Λ ∈ mixed
-        B, R = BR(Λ)
-        @test is_real_rotor(R; atol=ε)
-        @test is_pure_boost(B; atol=ε)
-        @test same_Λ(B * Lorentz(R), Λ; atol=ε)
+    using DoubleFloats: Double64
+    for T ∈ (Float32, Float64, Double64)
+        for Λ ∈ mixed(T)
+            B, R = BR(Λ)
+            cosh_half = abs(real(getfield(B, :components)[1]))
+            @test is_real_rotor(R; atol=128eps(T)*cosh_half)
+            @test is_pure_boost(B; atol=128eps(T)*cosh_half)
+            @test same_Λ(B * Lorentz(R), Λ; atol=32eps(T)*cosh_half)
+        end
     end
 end
 
@@ -176,7 +202,7 @@ end
     for T ∈ (Float32, Float64, Double64)
         ε = 100eps(T)
         for η ∈ T[0.3, 1.0, 2.5, 5.0]
-            for n̂ ∈ [QuatVec{T}(1,0,0), QuatVec{T}(0,1,0), QuatVec(T(1)/√T(3), T(1)/√T(3), T(1)/√T(3))]
+            for n̂ ∈ [QuatVec{T}(1,0,0), QuatVec{T}(0,1,0), QuatVec{T}(1,1,1)/√T(3)]
                 for θ ∈ T[π/6, π/3, 2π/3]
                     Λ = Lorentz(rotor(cos(θ/2), 0, 0, sin(θ/2))) * Boost(η, n̂)
                     R, B_rb = RB(Λ)
@@ -185,12 +211,13 @@ end
                 end
             end
         end
-    end
-    # Float64 accumulated products accumulate more error (~139 eps max on this data)
-    for Λ ∈ mixed
-        R, B_rb = RB(Λ)
-        B_br, _ = BR(Λ)
-        @test same_Λ(B_br, Lorentz(R) * B_rb * Lorentz(conj(R)); atol=256eps(Float64))
+        # Accumulated products: error scales as N×eps(T)×cosh(η/2), N≤16
+        for Λ ∈ mixed(T)
+            R, B_rb = RB(Λ)
+            B_br, _ = BR(Λ)
+            cosh_half = abs(real(getfield(B_rb, :components)[1]))
+            @test same_Λ(B_br, Lorentz(R) * B_rb * Lorentz(conj(R)); atol=32eps(T)*cosh_half)
+        end
     end
 end
 
@@ -204,7 +231,7 @@ end
         θ, η = T(1.3), T(0.8)
         n̂T = [1/√T(3), 1/√T(3), 1/√T(3)]
         B0 = Boost(η, n̂T)
-        R0 = Lorentz(rotor(cos(θ/2), sin(θ/2),0, 0))
+        R0 = Lorentz(rotor(cos(θ/2), sin(θ/2), 0, 0))
         Λ  = R0 * B0
         R, B = RB(Λ)
         maximum(abs, components(Lorentz(R) * B) - components(Λ))
@@ -229,7 +256,8 @@ end
 @testitem "Rv/vR: identity" tags=[:unit, :fast, :validation] setup=[LorentzDecompData] begin
     import Quaternionic: Rv, vR
     using .LorentzDecompData: same_Λ
-    for T ∈ (Float32, Float64)
+    using DoubleFloats: Double64
+    for T ∈ (Float32, Float64, Double64)
         ε = 10eps(T)
         Λ = one(Lorentz{T})
 
@@ -246,22 +274,26 @@ end
 @testitem "Rv/vR: pure rotation → zero velocity" tags=[:unit, :fast, :validation] setup=[LorentzDecompData] begin
     import Quaternionic: Rv, vR
     using .LorentzDecompData: rand_rotations, same_Λ
-    ε = 64eps(Float64)
-    for Λ ∈ rand_rotations
-        R, v⃗ = Rv(Λ)
-        @test norm(v⃗) ≤ ε
-        @test same_Λ(Lorentz(R), Λ; atol=ε)
+    using DoubleFloats: Double64
+    for T ∈ (Float32, Float64, Double64)
+        ε = 64eps(T)
+        for Λ ∈ rand_rotations(T)
+            R, v⃗ = Rv(Λ)
+            @test norm(v⃗) ≤ ε
+            @test same_Λ(Lorentz(R), Λ; atol=ε)
 
-        v⃗2, R2 = vR(Λ)
-        @test norm(v⃗2) ≤ ε
-        @test same_Λ(Lorentz(R2), Λ; atol=ε)
+            v⃗2, R2 = vR(Λ)
+            @test norm(v⃗2) ≤ ε
+            @test same_Λ(Lorentz(R2), Λ; atol=ε)
+        end
     end
 end
 
 @testitem "Rv/vR: pure boost → identity rotation and known velocity" tags=[:unit, :fast, :validation] setup=[LorentzDecompData] begin
     import Quaternionic: Rv, vR
     using .LorentzDecompData: is_real_rotor
-    for T ∈ (Float32, Float64)
+    using DoubleFloats: Double64
+    for T ∈ (Float32, Float64, Double64)
         ε = 64eps(T)
         for η ∈ T[0.375, 0.75, 1.5, 2.0]
             β = tanh(η)
@@ -295,9 +327,9 @@ end
     for T ∈ (Float32, Float64, Double64)
         ε = 10eps(T)
         for η ∈ T[0.3, 1.0, 2.5, 5.0]
-            for n̂ ∈ [QuatVec{T}(1,0,0), QuatVec{T}(0,1,0), QuatVec{T}(1, 1, 1)/√T(3)]
+            for n̂ ∈ [QuatVec{T}(1,0,0), QuatVec{T}(0,1,0), QuatVec{T}(1,1,1)/√T(3)]
                 for θ ∈ T[π/6, π/3, 2π/3]
-                    Λ = Lorentz(rotor(cos(θ/2), zero(T), zero(T), sin(θ/2))) * Boost(η, n̂)
+                    Λ = Lorentz(rotor(cos(θ/2), 0, 0, sin(θ/2))) * Boost(η, n̂)
                     R, v_rv = Rv(Λ)
                     v_vr, R2 = vR(Λ)
                     @test R == R2
@@ -305,13 +337,13 @@ end
                 end
             end
         end
-    end
-    # Float64 accumulated products and random inputs: equivariance still holds to ~2 eps
-    for Λ ∈ [mixed; rand_rotations; rand_boosts]
-        R, v_rv = Rv(Λ)
-        v_vr, R2 = vR(Λ)
-        @test R == R2
-        @test norm(v_vr - QuatVec(R * v_rv * conj(R))) ≤ 10eps(Float64)
+        # Accumulated products and random inputs: equivariance still holds to ~2 eps
+        for Λ ∈ [mixed(T); rand_rotations(T); rand_boosts(T)]
+            R, v_rv = Rv(Λ)
+            v_vr, R2 = vR(Λ)
+            @test R == R2
+            @test norm(v_vr - QuatVec(R * v_rv * conj(R))) ≤ 10eps(T)
+        end
     end
 end
 


### PR DESCRIPTION
Builds on `RB` and `BR` to compute velocity vector instead of `B` rotors